### PR TITLE
Feature/docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# Build output
+dist
+/spack
+/spack_*
+
+# Dependencies (installed inside container)
+node_modules
+
+# Git
+.git
+.gitignore
+.gitmodules
+
+# Environment files (secrets — pass via docker-compose environment: instead)
+.env
+.env.*
+
+# Docker files themselves (not needed in build context)
+docker-compose.yml
+docker/
+
+# IDE & OS
+.vscode/
+.DS_Store
+Thumbs.db
+
+# Docs & tools (not needed at runtime)
+docs/
+tools/
+README.md

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "solid-canvas"]
 	path = solid-canvas
-	url = git@github.com:ACKspace/solid-canvas.git
+	url = https://github.com/ACKspace/solid-canvas.git

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+services:
+
+  frontend:
+    build:
+      context: .
+      dockerfile: docker/frontend/Dockerfile
+    ports:
+      - "3001:3000"
+    volumes:
+      - .:/app
+      # Prevent host directory from overwriting the container's node_modules
+      - /app/node_modules
+    environment:
+      # Vite reads these at dev-server startup; browser-side vars must use localhost
+      VITE_TITLE: "spACK (dev)"
+      VITE_TOKEN_URL: "http://localhost:8083"
+    depends_on:
+      - token
+      - livekit
+
+  token:
+    build:
+      context: .
+      dockerfile: docker/token/Dockerfile
+    ports:
+      - "8083:8081"
+    volumes:
+      - ./public:/app/public:ro
+      - ./spACK_config.php:/app/spACK_config.php:ro
+    environment:
+      LIVEKIT_API_KEY: "devkey"
+      LIVEKIT_PASSWORD: "secret"
+      # URL returned to the browser — must be reachable from the user's machine
+      LIVEKIT_URL: "ws://localhost:7880/"
+      # Internal URL for server-side Twirp API calls within the Docker network
+      LIVEKIT_INTERNAL_URL: "ws://livekit:7880/"
+    depends_on:
+      - livekit
+
+  livekit:
+    image: livekit/livekit-server:latest
+    ports:
+      - "7880:7880"
+    # --dev enables built-in devkey/secret API key pair and disables TLS
+    command: ["--dev", "--bind", "0.0.0.0"]

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:24-alpine
+
+# git is required by vite.config.ts (git describe/log/rev-parse calls at build time)
+RUN apk add --no-cache git && \
+    git config --global --add safe.directory /app
+
+WORKDIR /app
+
+# Install dependencies first (cached layer)
+COPY package*.json ./
+RUN npm install
+
+EXPOSE 3000
+
+CMD ["sh", "-c", "git submodule update --init --recursive && npm start -- --host 0.0.0.0"]

--- a/docker/token/Dockerfile
+++ b/docker/token/Dockerfile
@@ -1,0 +1,8 @@
+FROM php:8-cli-alpine
+
+WORKDIR /app
+
+EXPOSE 8081
+
+# DOCUMENT_ROOT is /app/public; spACK_config.php is loaded from one level up (/app)
+CMD ["php", "-S", "0.0.0.0:8081", "-t", "/app/public", "/app/public/token/index.php"]

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -9,6 +9,7 @@ This document describes to set up and run your local instance, deployment and de
   * [MacOS](#1.2)
   * [Linux](#1.3)
 * [Developing](#2)
+  * [Docker Compose (alternative)](#2.0)
   * [Client](#2.1)
   * [Local token server](#2.2)
   * [Committing code](#2.3)
@@ -80,20 +81,16 @@ $ sudo apt install ./vscode.deb
 Checkout this repository from GitHub and make sure the submodules are also cloned:
 ```bash
 git clone https://github.com/ACKspace/spACK.git
-# or git clone git@github.com:ACKspace/spACK.git
 cd spACK
 git submodule update --init --recursive
 ```
+
+> **Note:** the `solid-canvas` submodule uses HTTPS, so no SSH key is required for it.
 
 After the initial repository and submodules are cloned, you can pull in updates (from within the project's directory) with:
 ```bash
 git pull
 git submodule update --recursive --remote
-```
-
-Provide your local instance with the latest node modules:
-```bash
-$ npm install # or npm i
 ```
 
 Copy over the `.env.example` file to `.env`:
@@ -102,7 +99,48 @@ $ cp .env.example .env
 ```
 
 
+### Docker Compose (alternative) <a id="2.0"></a>
+
+If you have Docker and Docker Compose installed, you can run a full local stack (frontend, token server, LiveKit) without installing Node.js, PHP, or the LiveKit binary manually.
+
+```bash
+$ docker compose up --build
+```
+
+This starts three services:
+
+| Service | URL | Description |
+|---|---|---|
+| `frontend` | http://localhost:3001 | Vite dev server with hot reload |
+| `token` | http://localhost:8083 | PHP JWT token server |
+| `livekit` | ws://localhost:7880 | LiveKit WebRTC server (dev mode) |
+
+Update your `.env` file to point at the Docker token server:
+```
+VITE_TOKEN_URL=http://localhost:8083
+```
+
+The frontend service mounts the project source as a volume, so edits to `src/` hot-reload automatically. The token service mounts `public/` and `spACK_config.php` directly, so PHP changes also take effect immediately without a rebuild.
+
+To override LiveKit credentials or URLs, set environment variables before running:
+```bash
+export LIVEKIT_API_KEY=mykey
+export LIVEKIT_PASSWORD=mypassword
+docker compose up
+```
+
+To stop all services:
+```bash
+$ docker compose down
+```
+
+
 ### Client <a id="2.1"></a>
+
+Install dependencies:
+```bash
+$ npm install # or npm i
+```
 
 Start local development instance:
 ```bash
@@ -116,22 +154,24 @@ You will need a local LiveKit server running that handles the conference and Web
 
 ### Local token server <a id="2.2"></a>
 
+`spACK_config.php` is already present in the repository and reads its settings from environment variables with built-in defaults suitable for local development (`devkey` / `secret` / `ws://localhost:7880/`). No manual creation is needed.
+
+To use the token server locally without Docker:
+
 * Update the `.env` file: `VITE_TOKEN_URL=http://localhost:8081`
-* Create `spACK_config.php` in the project root (just outside the `public` directory) with the following content:
-```php
-<?php
-define("API_KEY", "devkey");
-define("PASSWORD", "secret");
-// Used for LiveKitRoom websocket serverUrl and Twirp Roomservice POST
-define("URL", "ws://127.0.0.1:7880");
-// Alternatively, use online server
-//define("URL", "https://pauper.tel/livekit/");
-```
 * Run local php instance of token service:
 ```bash
 npm run token
 # or:
 php -S 0.0.0.0:8081 -t ./public public/token/index.php
+```
+
+To override the defaults, set environment variables before starting the token server:
+```bash
+export LIVEKIT_API_KEY=mykey
+export LIVEKIT_PASSWORD=mypassword
+export LIVEKIT_URL=ws://127.0.0.1:7880/
+npm run token
 ```
 
 ### Committing code <a id="2.3"></a>
@@ -210,13 +250,25 @@ Environment defaults to `test`.
 
 ### Token server config <a id="3.4"></a>
 
-* Create `spACK_config.php` just outside the public html directory with the following content:
-```php
-<?php
-define("API_KEY", "devkey");
-define("PASSWORD", "secret");
-// Point to LiveKit server; used for LiveKitRoom websocket serverUrl and Twirp Roomservice POST
-define("URL", "https://pauper.tel/livekit/");
+`spACK_config.php` is included in the repository and reads credentials from environment variables. On the deployment server, set these variables in your web server configuration (e.g. Apache `SetEnv`, nginx `fastcgi_param`) or a server-side environment file:
+
+```
+LIVEKIT_API_KEY=<your-api-key>
+LIVEKIT_PASSWORD=<your-admin-password>
+LIVEKIT_URL=https://your-livekit-host/
+```
+
+`LIVEKIT_INTERNAL_URL` can optionally be set if the server-side API endpoint differs from the browser-facing WebSocket URL (e.g. in Docker or behind a reverse proxy). It defaults to the value of `LIVEKIT_URL`.
+
+For Apache, environment variables can be set per virtual host:
+```conf
+<VirtualHost *:443>
+    #... current settings
+
+    SetEnv LIVEKIT_API_KEY     your-api-key
+    SetEnv LIVEKIT_PASSWORD    your-admin-password
+    SetEnv LIVEKIT_URL         https://your-livekit-host/
+</VirtualHost>
 ```
 
 
@@ -252,3 +304,4 @@ And add the following two lines to your virtualhost config:
     ProxyPass /livekit ws://127.0.0.1:7880
     ProxyPassReverse /livekit ws://127.0.0.1:7880
 </VirtualHost>
+```

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -154,7 +154,7 @@ You will need a local LiveKit server running that handles the conference and Web
 
 ### Local token server <a id="2.2"></a>
 
-`spACK_config.php` is already present in the repository and reads its settings from environment variables with built-in defaults suitable for local development (`devkey` / `secret` / `ws://localhost:7880/`). No manual creation is needed.
+`spACK_config.php` is already present in the repository and reads its settings from environment variables. The defaults (`devkey` / `secret`) point at the production LiveKit server, so no manual creation is needed for basic use.
 
 To use the token server locally without Docker:
 

--- a/public/token/helpers.php
+++ b/public/token/helpers.php
@@ -114,7 +114,8 @@ function getMetadata($room)
 
     $roomFolder = preg_replace('/[^A-Za-z0-9\-_]/', '_', $roomFolder);
 
-    $path = "../world/".$roomFolder."/metadata.json";
+    // __DIR__ is public/token/; /../world/ resolves to public/world/
+    $path = __DIR__."/../world/".$roomFolder."/metadata.json";
     if (file_exists($path)) {
         // Load metadata
         $metadata = json_decode(file_get_contents($path));
@@ -153,9 +154,10 @@ function createRoom($token, $metadata)
 
     // error_log(json_encode($data), 0);
 
-    // Do LiveKit request.
+    // Do LiveKit request (use INTERNAL_URL to support Docker/reverse-proxy setups
+    // where the browser-facing URL differs from the server-side API endpoint).
     postJson(
-        $token->ws_url."twirp/livekit.RoomService/CreateRoom",
+        INTERNAL_URL."twirp/livekit.RoomService/CreateRoom",
         $token->token,
         $data
     );

--- a/public/token/index.php
+++ b/public/token/index.php
@@ -14,20 +14,24 @@
 // error_reporting(E_ALL);
 // ini_set('display_errors', 'On');
 
-// Load config, suppress warnings.
-if (!@include_once $_SERVER['DOCUMENT_ROOT']."/../spACK_config.php") {
-    header("HTTP/1.1 500 Internal server error", true, 500);
-    echo '{"error":"Config file not found!"}';
-    exit(0);
-}
-// Load helper, suppress warnings.
-if (!@include_once "./helpers.php") {
+// Load helper first so cors() is available for all responses (including errors).
+// helpers.php has no dependency on the config file.
+if (!@include_once __DIR__ . "/helpers.php") {
     header("HTTP/1.1 500 Internal server error", true, 500);
     echo '{"error":"Helpers file not found!"}';
     exit(0);
 }
 
 cors();
+
+// Use __DIR__ to locate spACK_config.php reliably regardless of how the PHP
+// server sets DOCUMENT_ROOT (built-in server, Apache, Docker, etc.).
+// __DIR__ = public/token/, so ../../ = project root.
+if (!@include_once __DIR__ . "/../../spACK_config.php") {
+    header("HTTP/1.1 500 Internal server error", true, 500);
+    echo '{"error":"Config file not found!"}';
+    exit(0);
+}
 
 $data = json_decode(file_get_contents('php://input'), true);
 $room = isset($data["room"]) ? $data["room"] : "Dark";
@@ -38,8 +42,8 @@ $debug = isset($data["debug"]) ? $data["debug"] : false;
 // TODO: HMAC encoded
 $password = isset($data["password"]) ? $data["password"] : "";
 $metadata = getMetadata($room);
-$isUser = $password === ($metadata->pass ?? "") || $password === ($metadata->admin ?? "");
-$isAdmin = $password === ($metadata->admin ?? "");
+$isUser = $password === ($metadata?->pass ?? "") || $password === ($metadata?->admin ?? "");
+$isAdmin = $password === ($metadata?->admin ?? "");
 
 $attributes = new stdClass();
 $attributes->character = $character;

--- a/spACK_config.php
+++ b/spACK_config.php
@@ -1,8 +1,7 @@
 <?php
-define("API_KEY", "devkey");
-define("PASSWORD", "secret");
-// Used for LiveKitRoom websocket serverUrl and Twirp Roomservice POST
-// Use online server
-define("URL", "https://pauper.tel/livekit/");
-// Alternatively, use local server
-// define("URL", "ws://127.0.0.1:7880");
+define("API_KEY", getenv("LIVEKIT_API_KEY") ?: "devkey");
+define("PASSWORD", getenv("LIVEKIT_PASSWORD") ?: "secret");
+// Browser-facing WebSocket URL (returned to client as ws_url)
+define("URL", getenv("LIVEKIT_URL") ?: "ws://localhost:7880/");
+// Internal URL for server-side Twirp API calls (can differ from URL in Docker)
+define("INTERNAL_URL", getenv("LIVEKIT_INTERNAL_URL") ?: URL);

--- a/spACK_config.php
+++ b/spACK_config.php
@@ -2,6 +2,6 @@
 define("API_KEY", getenv("LIVEKIT_API_KEY") ?: "devkey");
 define("PASSWORD", getenv("LIVEKIT_PASSWORD") ?: "secret");
 // Browser-facing WebSocket URL (returned to client as ws_url)
-define("URL", getenv("LIVEKIT_URL") ?: "ws://localhost:7880/");
+define("URL", getenv("LIVEKIT_URL") ?: "https://pauper.tel/livekit/");
 // Internal URL for server-side Twirp API calls (can differ from URL in Docker)
 define("INTERNAL_URL", getenv("LIVEKIT_INTERNAL_URL") ?: URL);

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -180,7 +180,7 @@ export async function setRoomMetaData(room: string, metadata: string): Promise<n
   // TODO: we can check for token.admin or just let it error out
 
   try {
-    const data = await (await fetch(`${roomInfo().ws_url.replace("wss://", "https://")}twirp/livekit.RoomService/UpdateRoomMetadata`, {
+    const data = await (await fetch(`${roomInfo().ws_url.replace("wss://", "https://").replace("ws://", "http://")}twirp/livekit.RoomService/UpdateRoomMetadata`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/src/utils/useParticipants.ts
+++ b/src/utils/useParticipants.ts
@@ -16,7 +16,7 @@ export const useParticipants = async (roomInfo: Token): Promise<RoomParticipants
   }
 
   try {
-    const data = await (await fetch(`${roomInfo.ws_url.replace("wss://", "https://")}twirp/livekit.RoomService/ListParticipants`, {
+    const data = await (await fetch(`${roomInfo.ws_url.replace("wss://", "https://").replace("ws://", "http://")}twirp/livekit.RoomService/ListParticipants`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -25,20 +25,19 @@ export const useParticipants = async (roomInfo: Token): Promise<RoomParticipants
       body: JSON.stringify({ room: roomInfo.room }),
     })).json();
 
-    // Status 401
+    // Status 401 or room not found — don't clear the token, just report
+    // the issue and fall back to the token's own permissions so join/admin
+    // state remains correct in the UI.
     if ("msg" in data) {
-      // Payload contains `msg` and `code`, not `rooms`.
-      console.warn("Failed to list rooms:", data.msg);
-      clearCachedToken();
-      return { participants: [], error: `Could not fetch token: ${data.msg}` };
+      console.warn("Failed to list participants:", data.msg);
+      return { participants: [], list: roomInfo?.list, join: roomInfo?.join, admin: roomInfo?.admin };
     }
 
     // If room does not exist, return empty list
     return { participants: data.participants, list: roomInfo?.list, join: roomInfo?.join, admin: roomInfo?.admin };
   } catch (e) {
-    console.warn("Failed to list rooms, clearing cached token.", e);
-    clearCachedToken();
-    return { participants: [], error: `Fetch error: ${e?.stack ?? e?.message}` };    
+    console.warn("Failed to list participants:", e);
+    return { participants: [], list: roomInfo?.list, join: roomInfo?.join, admin: roomInfo?.admin };
   }
 }
 
@@ -61,7 +60,7 @@ export async function deleteRoom(room: string, token: Token): Promise<boolean>
   // TODO: we can check for token.admin or just let it error out
 
   try {
-    const data = await (await fetch(`${token.ws_url.replace("wss://", "https://")}twirp/livekit.RoomService/DeleteRoom`, {
+    const data = await (await fetch(`${token.ws_url.replace("wss://", "https://").replace("ws://", "http://")}twirp/livekit.RoomService/DeleteRoom`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,7 +32,9 @@ export default ({ mode }: ConfigEnv) => {
       emptyOutDir: true,
     },
     optimizeDeps: {
-      // exclude: ["solid-canvas/*"],
+      // Limit dependency scanning to the app's own source so Vite doesn't
+      // crawl solid-canvas/dev/ which has self-referential dev-only imports.
+      entries: ["index.html", "src/**/*.{ts,tsx}"],
     },
   };
 }


### PR DESCRIPTION
Add optional Docker Compose support (`docker compose up --build`) for running the full local stack without installing Node.js, PHP, or LiveKit manually. The existing workflow is unchanged.

Introduced four new files for Docker infrastructure:
- `docker-compose.yml` defines three services: `frontend`, `token`, and `livekit`
- `docker/frontend/Dockerfile`: Node 24 Alpine, git, submodule init, Vite dev server
- `docker/token/Dockerfile`: PHP 8 CLI Alpine, token server
- `.dockerignore`: excludes `node_modules/`, `.git/`, `.env`, and `dist/`.

Changes to `.gitmodules`:
- Docker build environment has no SSH key, so when `docker/frontend/Dockerfile` runs `git submodule update --init --recursive` inside the container, it can't authenticate with GitHub over SSH. HTTPS requires no credentials for public repositories, so the submodule can be cloned without any key setup.

Changes to `spACK_config.php`:
- Replaced hardcoded constants with `getenv()` and defaults.
- Added `INTERNAL_URL` to separate browser-facing URL from PHP-side Twirp API URL.

Changes to `public/token/index.php`:
- Load `helpers.php` first so `cors()` fires before any `exit()` (was silently breaking CORS on errors.
- `__DIR__` based paths instead of `$_SERVER['DOCUMENT_ROOT']` (unreliable with router scripts).
- Used `?->` nullsafe operator for 8.2+ compatibility.

Changes to `public/token/helpers.php`:
- `__DIR__`-based path for `world/` lookup.
- Use `INTERNAL_URL` for Twirp API calls.

Changes to `src/utils/useParticipants.ts`:
- Changed `ws://` to `http://` protocol for local LiveKit (see note at the bottom).
- Stop clearing token + dropping `join/admin` on non-critical errors (was showing false "password protected").

Changes to ` src/utils/token.ts`:
- Changed `ws://` to `http://` protocol (see note at the bottom).

Changes to `vite.config.ts`:
- Limit `optimizeDeps` scanning to `src/` to prevent Vite from choking on `solid-canvas/dev`'s self-referential imports.

Changes to `docs/Development.md`:
- Documented instructions for alternative workflow using Docker (may require revision).

Note on protocol change:
- LiveKit Twirp API is an HTTP RPC endpoint, not a WebSocket endpoint. It uses regular HTTP POST requests (`fetch()`).
- `fetch()` only accepts `http://` or `https://` schemes.